### PR TITLE
feat: ignore user ids via config

### DIFF
--- a/nonebot_plugin_binsearch/__init__.py
+++ b/nonebot_plugin_binsearch/__init__.py
@@ -12,6 +12,9 @@ from nonebot.exception import FinishedException
 from .api import query_bin_info
 from .image import create_bin_image
 
+# 读取插件配置
+plugin_config = get_plugin_config(Config)
+
 __plugin_meta__ = PluginMetadata(
     name="卡bin查询",
     description="用于查询信用卡的卡组织，卡等级，卡类型，发卡国家或地区等 (图片版)",
@@ -26,6 +29,11 @@ bin_query = on_command('bin', aliases={'BIN','Bin'}, priority=5, block=True)
 
 @bin_query.handle()
 async def handle_bin_query(bot: Bot, event: Event, arg: Message = CommandArg()):
+    # 忽略来自配置中的用户ID
+    user_id = event.get_user_id()
+    ignore_ids = {str(uid) for uid in getattr(plugin_config, 'ignore_user_ids', [])}
+    if user_id in ignore_ids:
+        return
     bin_number = arg.extract_plain_text().strip()
 
     if not bin_number:

--- a/nonebot_plugin_binsearch/config.py
+++ b/nonebot_plugin_binsearch/config.py
@@ -3,3 +3,5 @@ from pydantic import BaseModel
 
 class Config(BaseModel):
     bin_api_key: str
+    # 忽略的 QQ 用户 ID 列表（字符串或数字均可）
+    ignore_user_ids: list[str] = [3938088854]


### PR DESCRIPTION
- 新增 Config.ignore_user_ids 配置字段，默认包含你当前配置的 QQ；\n- 在 __init__.py 中读取配置，并在 handle_bin_query 开头忽略来自该列表的用户；\n- 不影响现有功能；支持通过 .env / 环境变量注入配置。